### PR TITLE
All pastes now have a pasted insert event id.

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -1009,6 +1009,9 @@ function handleTextEditorChange(event) {
                             //store the pasted event ids
                             pastedInsertEventIds = clipboardData.eventIds;
                         } else { //this is a paste but it doesn't match the last storyteller copy/cut (pasted from another source)
+                            //create an array of strings with 'other' for the paste event ids to signify a paste from outside the editor
+                            pastedInsertEventIds = newText.split('').map(() => 'other');
+
                             //clear out any old data
                             clipboardData.text = '';
                             clipboardData.eventIds = [];


### PR DESCRIPTION
If a paste happens from a copy outside of the editor then I store the text 'other' as the pasted event id in the insert event.

I will use this to know when a paste from outside storyteller happens (if the paste is from a copy that happened in storyteller then I already store the insert event's id in the Insert event's pastedEventId).