### PR TITLE
Fixed two bugs

### DIFF
--- a/core/project/ProjectManager.js
+++ b/core/project/ProjectManager.js
@@ -548,12 +548,24 @@ class ProjectManager extends FileBackedCollection {
         //get all the events from the file
         const events = this.eventManager.read();
 
+        //make sure the comment urls don't have a leading slash
+        const copyOfComments = Object.assign({}, this.commentManager.comments);
+        for(let eventId in copyOfComments) {
+            const comments = copyOfComments[eventId];
+            for(let i = 0;i < comments.length;i++) {
+                const comment = comments[i];
+                comment.imageURLs = comment.imageURLs.map(imageURL => imageURL[0] === '/' ? imageURL.substring(1) : imageURL);
+                comment.videoURLs = comment.videoURLs.map(videoURL => videoURL[0] === '/' ? videoURL.substring(1) : videoURL);
+                comment.audioURLs = comment.audioURLs.map(audioURL => audioURL[0] === '/' ? audioURL.substring(1) : audioURL);
+            }
+        }
+
         //create the text for a js function that loads the playback into a global called playbackData
         const func = 
 `
 function loadPlaybackData() {
     playbackData.events = ${JSON.stringify(events)};
-    playbackData.comments = ${JSON.stringify(this.commentManager.comments)};
+    playbackData.comments = ${JSON.stringify(copyOfComments)};
     playbackData.numEvents = ${events.length};
     playbackData.isEditable = ${makeEditable ? 'true' : 'false'};
     playbackData.developers = ${JSON.stringify(this.developerManager.allDevelopers)};

--- a/extension.js
+++ b/extension.js
@@ -1252,7 +1252,7 @@ function zipProjectHelper(dirPath, zip) {
             normalizedFilePath = normalizedFilePath.substr(1);
 
             //read the contents of the file
-            const fileContents = fs.readFileSync(fullPathToFileOrDir, 'utf8');
+            const fileContents = fs.readFileSync(fullPathToFileOrDir);
             
             //add the file to the zip
             zip.file(normalizedFilePath, fileContents);
@@ -1357,7 +1357,7 @@ function zipPublicHelper(dirPath, zip) {
         //if this is a file
         if(stats.isFile()) {
             //read the contents of the file
-            const fileContents = fs.readFileSync(fullPathToFileOrDir, 'utf8');
+            const fileContents = fs.readFileSync(fullPathToFileOrDir);
             
             //add the file to the zip
             zip.file(relativePathToFileOrDir, fileContents);


### PR DESCRIPTION
Bug 1: I was reading media files as utf8 when making a zip. Now I use a stream.

Bug 2: I removed leading slashes in the media URLs when making a playback only zip file since they caused a problem when serving from the file system.