### PR TITLE
Paste images on the clipboard into a new/editable comment.

### DIFF
--- a/core/public/js/aceEditorManager.js
+++ b/core/public/js/aceEditorManager.js
@@ -38,6 +38,9 @@ function createAceEditor(codeDiv, filePath, fileId)
     setEditorMode(tempEditor, filePath);
     //make it possible to scroll past the end of the text
     tempEditor.setOptions({scrollPastEnd: true});
+    //remove the cursor
+    tempEditor.setOptions({highlightActiveLine: false, highlightGutterLine: false});
+    tempEditor.renderer.$cursorLayer.element.style.display = "none";
 
     //adds editor as a key/value pair to the list of editors using fileId as the key
     playbackData.editors[fileId] = tempEditor;
@@ -98,10 +101,6 @@ function addCodeHighlights(commentObject) {
         //add the secondary highlight
         addSecondaryCodeHighlight(fileId, secondaryHighlightStartRow, secondaryHighlightEndRow);
     }
-    //get the editor where the highlight will take place and remove the cursor
-    const editor = playbackData.editors[fileId];
-    editor.setOptions({highlightActiveLine: false, highlightGutterLine: false});
-    editor.renderer.$cursorLayer.element.style.display = "none";
 }
 /*
  * Cretes a group of Ace ranges for primary highlights. It goes through a (possible multi-line) range

--- a/core/public/js/playbackInit.js
+++ b/core/public/js/playbackInit.js
@@ -261,7 +261,9 @@ function setupEventListeners()
     }); 
 
     document.querySelector('#addCommentButton').addEventListener('click', async event => {        
-        stopAutomaticPlayback();        
+        const commentEditable = document.querySelector('#commentEditable');
+        commentEditable.dataset.commentEditable = false;
+        stopAutomaticPlayback();
         clearHighlights();
 
         //if the user entered a tag but forgot to add it, add it now
@@ -398,7 +400,8 @@ function setupEventListeners()
 
     document.getElementById("CancelUpdateButton").addEventListener('click', event => {
         stopAutomaticPlayback();
-
+        const commentEditable = document.querySelector('#commentEditable');
+        commentEditable.dataset.commentEditable = false;
         document.querySelector('.createCommentQuestionCheckbox').classList.remove('hiddenDiv');
 
         const imagePreviewDiv = document.getElementsByClassName("image-preview")[0];
@@ -595,7 +598,11 @@ function setupEventListeners()
     makeDivDroppable($('.video-preview')[0], false);
     makeDivDroppable($('.audio-preview')[0], false);
 
-    document.getElementById("mainAddCommentButton").addEventListener('click', event => {     
+    document.getElementById("mainAddCommentButton").addEventListener('click', event => {  
+        //indicate that the user is editing a comment
+        const commentEditable = document.querySelector('#commentEditable');
+        commentEditable.dataset.commentEditable = true;
+        
         stopAutomaticPlayback();
         clearHighlights();
 

--- a/core/public/js/st-ui.js
+++ b/core/public/js/st-ui.js
@@ -540,6 +540,9 @@ function createEditCommentButton(commentObject, buttonText) {
         //prevents the edit button from triggering the event listeners of its parent divs
         event.preventDefault();
         event.stopPropagation();
+        const commentEditable = document.querySelector('#commentEditable');
+        commentEditable.dataset.commentEditable = true;
+
 
         if (commentObject.id === "commentId-0") {
             document.querySelector('.createCommentQuestionCheckbox').classList.add('hiddenDiv');
@@ -649,7 +652,9 @@ function createEditCommentButton(commentObject, buttonText) {
   
         updateCommentButton.addEventListener( 'click' ,async event => {
             event.stopImmediatePropagation();
-
+            const commentEditable = document.querySelector('#commentEditable');
+            commentEditable.dataset.commentEditable = false;
+    
             pauseMedia();
             //get the active editor
             const editor = playbackData.editors[playbackData.activeEditorFileId] ? playbackData.editors[playbackData.activeEditorFileId] : playbackData.editors[''];

--- a/core/public/playback.html
+++ b/core/public/playback.html
@@ -126,7 +126,7 @@
                     </div>
     
                     <div id="addCommentPanel" class="tab-pane commentsDivScroll">
-                        
+                        <div id="commentEditable" data-commentEditable="false" hidden></div>
                         <div class="form-group">
                             <div id="textCommentTextArea" contenteditable="true" class="form-control storytellerCommentEditable" data-ph="Comment Text"></div>
                             <div class="input-group input-group-sm mb-3">


### PR DESCRIPTION
This feature allows the user to copy an image to the clipboard (using the file explorer or a screenshot tool) and then paste it into the media pop up in a single step. This saves the user from having to save the screenshot and then select it from the file system.

Bug fixes: deleting audios and videos was not working I updated the query selector to fix it. I also moved hiding the cursor to the function that creates editors.